### PR TITLE
safariでPopupを開けるようにする

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -28,6 +28,7 @@ const KosodateMap = () => {
     <MapContainer
       center={position}
       zoom={13}
+      tap={false} // to support safari https://github.com/Leaflet/Leaflet/issues/7266
       scrollWheelZoom={true}
       style={{ height: "100vh" }}
     >


### PR DESCRIPTION
Leafletにて、safariでポップアップを開けない問題があるらしい。
https://github.com/Leaflet/Leaflet/issues/7266

## 変更点
Mapエレメントのtapをfalseに設定。

以下環境で動作確認済
- MacOS Catalina 10.15.1
- Safari 13.0.3