### PR TITLE
release時にgithub pagesにpublishする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: push
+on: pull_request
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Node CI
+name: build
 
 on: push
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,13 +19,13 @@ jobs:
         node-version: '14'
         check-latest: true
 
-    - name: build
+    - name: Build
       run: |
         npm install
         npm run build
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./public

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: deploy
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup node
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+        check-latest: true
+
+    - name: build
+      run: |
+        npm install
+        npm run build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public


### PR DESCRIPTION
#26 
## 変更点
- release時にgithub pagesにpublishする
- github actionsのbuild jobはpull-request時にのみ走るようにする
    - 既存では各ブランチに対するpushでもbuildが走り、冗長だったため