### PR TITLE
kosodate-mapに、CodeForFunabashiへのリンクを表示する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # kosodate-map
-船橋市の子育て情報がひと目でわかる地図
+船橋市の子育て情報がひと目でわかる地図  
+https://code-for-funabashi.github.io/kosodate-map/
 
 ## Usage
 ```bash

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="船橋子育て地域マップ"
+      content="船橋市の子育て情報がひと目でわかる地図。"
     />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -45,7 +45,7 @@ const KosodateMap = () => {
       style={{ height: "100vh" }}
     >
       <TileLayer
-        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors | <a href="http://code4funabashi.org/">CodeForFunabashi</a>'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
       {pointCatalog.map((item) => PointLayer(item))}


### PR DESCRIPTION
## 変更点
- KosodateMapにCodeForFunabashiのホームページのリンクを追加(#25 )
- README.mdに、github pagesへのリンクを追加
- ページのlangとmeta descriptionを修正