### PR TITLE
LayersControl.Ocerlayにkeyを追加

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -24,9 +24,9 @@ const Map = (props: { pointCatalog: PointMeta[] }) => {
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
       <LayersControl position="topright">
-        {props.pointCatalog.map((item) => {
+        {props.pointCatalog.map((item, index) => {
           return (
-            <LayersControl.Overlay name={item.type} checked>
+            <LayersControl.Overlay name={item.type} key={index} checked>
               <LayerGroup>{PointLayer(item)}</LayerGroup>
             </LayersControl.Overlay>
           );


### PR DESCRIPTION
#61のkeyが設定されてないためデベロッパーツールにてエラーに記述されていたソースと同じ修正をしました。
ディベロッパーツールでのエラーは表示されないことを確認しました。