### PR TITLE
年月の説明を変更

### DIFF
--- a/src/components/Map/NurserySchoolTooltip.tsx
+++ b/src/components/Map/NurserySchoolTooltip.tsx
@@ -13,7 +13,7 @@ export const NurserySchoolTooltip = (props: {
 
       <div className={tooltip.contents}>
         <div>
-          データ取得月: {props.meta.year}年{props.meta.month}月
+          対象年月: {props.meta.year}年{props.meta.month}月
         </div>
         <div className={tooltip.categories}>
           <span className={tooltip.category}>{props.point.details.type}</span>


### PR DESCRIPTION
もともとはデータ取得日を表示することを想定していたが、
受け入れ可能人数については、未来の見込み人数が表示されるため、記載を変更する